### PR TITLE
adding sidebar-map class to map

### DIFF
--- a/examples/leaflet-api.html
+++ b/examples/leaflet-api.html
@@ -30,7 +30,7 @@
 </head>
 <body>
 
-    <div id="map"></div>
+    <div id="map" class="sidebar-map"></div>
 
     <a href="https://github.com/Turbo87/sidebar-v2/"><img style="position: fixed; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 


### PR DESCRIPTION
The leaflet-api.html example doesn't show the zoom controls (they are hidden behind the sidebar). This is because the #map div doesn't have the class 'sidebar-map'.