### PR TITLE
Disable right-click propagation

### DIFF
--- a/js/leaflet-sidebar.js
+++ b/js/leaflet-sidebar.js
@@ -176,6 +176,7 @@ L.Control.Sidebar = L.Control.extend(/** @lends L.Control.Sidebar.prototype */ {
         // when adding to the map container, we should stop event propagation
         L.DomEvent.disableScrollPropagation(this._container);
         L.DomEvent.disableClickPropagation(this._container);
+        L.DomEvent.on(this._container, 'contextmenu', L.DomEvent.stopPropagation);
 
         // insert as first child of map container (important for css)
         map._container.insertBefore(this._container, map._container.firstChild);


### PR DESCRIPTION
Currently the sidbar does not stop the propagation of right clicks. So if you have a right-click listener on the map and right-click on the sidebar, the event will be triggered on the map. This change stops the propagation.